### PR TITLE
Update Node's trusted release keys

### DIFF
--- a/bin/package-lock.json
+++ b/bin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bin",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/bin/package.json
+++ b/bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bin",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "description": "",
   "main": "dsx-cli.js",
   "scripts": {

--- a/node.js
+++ b/node.js
@@ -41,6 +41,8 @@ const keys =
     "    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 ", // Michaël Zasso <targos@protonmail.com>, Node release team
     "    A48C2BEE680E841632CD4E44F07496B3EB3C1762 ", // Ruben Bridgewater <ruben@bridgewater.de>, Node release team
     "    B9E2F5981AA6E0CD28160D9FF13993A75599653C ", // Shelley Vohr <shelley.vohr@gmail.com>, Node release team
+    "    C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C ", // Richard Lau <riclau@uk.ibm.com>, Node release team
+    "    108F52B48DB57BB0CC439B2997B01419BD92F80A ", // Ruy Adorno <ruyadorno@hotmail.com>, Node release team
     "  ; do ",
     "    gpg --keyserver na.pool.sks-keyservers.net --recv-keys \"$key\" || ",
     "    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \"$key\" || ",

--- a/node.js
+++ b/node.js
@@ -33,6 +33,9 @@ const keys =
     "    B9AE9905FFD7803F25714661B63B535A4C206CA9 ", // Evan Lucas <evanlucas@me.com>, former member of Node release team
     "    77984A986EBC2AA786BC0F66B01FBB92821C587A ", // Gibson Fahnestock <gibfahn@gmail.com>, former member of Node release team
     "    FD3A5288F042B6850C66B31F09FE44734EB7990E ", // Jeremiah Senkpiel <fishrock@keybase.io>, former member of Node release team
+    "    93C7E9E91B49E432C2F75674B0A78B0A6C481CF6 ", // Isaac Z. Schlueter <i@izs.me>, former member of Node release team
+    "    114F43EE0176B71C7BC219DD50A3051F888C628D ", // Julien Gilli <jgilli@fastmail.fm>, former member of Node release team
+    "    7937DFD2AB06298B2293C3187D33FF9D0246406D ", // Timothy J Fontaine <tjfontaine@gmail.com>, former member of Node release team
     "    4ED778F539E3634C779C87C6D7062848A1AB005C ", // Beth Griggs <bethany.griggs@uk.ibm.com>, Node release team
     "    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 ", // Colin Ihrig <cjihrig@gmail.com>, Node release team
     "    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 ", // James M Snell <jasnell@keybase.io>, Node release team

--- a/node.js
+++ b/node.js
@@ -30,13 +30,13 @@ const keys =
     "    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 ", // keybase.io/octetcloud, likely a former member member of Node release team
     "    56730D5401028683275BD23C23EFEFE93C4CFFFE ", // Italo A. Casas <me@italoacasas.com>, former member of Node release team
     "    9554F04D7259F04124DE6B476D5A82AC7E37093B ", // Chris Dickinson <christopher.s.dickinson@gmail.com>, former member of Node release team
+    "    B9AE9905FFD7803F25714661B63B535A4C206CA9 ", // Evan Lucas <evanlucas@me.com>, former member of Node release team
+    "    77984A986EBC2AA786BC0F66B01FBB92821C587A ", // Gibson Fahnestock <gibfahn@gmail.com>, former member of Node release team
+    "    FD3A5288F042B6850C66B31F09FE44734EB7990E ", // Jeremiah Senkpiel <fishrock@keybase.io>, former member of Node release team
     "    4ED778F539E3634C779C87C6D7062848A1AB005C ", // Beth Griggs <bethany.griggs@uk.ibm.com>, Node release team
     "    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 ", // Colin Ihrig <cjihrig@gmail.com>, Node release team
-    "    FD3A5288F042B6850C66B31F09FE44734EB7990E ", // Jeremiah Senkpiel <fishrock@keybase.io>, Node release team
     "    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 ", // James M Snell <jasnell@keybase.io>, Node release team
     "    DD8F2338BAE7501E3DD5AC78C273792F7D83545D ", // Rod Vagg <rod@vagg.org>, Node release team
-    "    B9AE9905FFD7803F25714661B63B535A4C206CA9 ", // Evan Lucas <evanlucas@me.com>, Node release team
-    "    77984A986EBC2AA786BC0F66B01FBB92821C587A ", // Gibson Fahnestock <gibfahn@gmail.com>, Node release team
     "    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 ", // Myles Borins <myles.borins@gmail.com>, Node release team
     "    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 ", // Michaël Zasso <targos@protonmail.com>, Node release team
     "    A48C2BEE680E841632CD4E44F07496B3EB3C1762 ", // Ruben Bridgewater <ruben@bridgewater.de>, Node release team
@@ -45,7 +45,7 @@ const keys =
     "    108F52B48DB57BB0CC439B2997B01419BD92F80A ", // Ruy Adorno <ruyadorno@hotmail.com>, Node release team
     "  ; do ",
     "    gpg --keyserver na.pool.sks-keyservers.net --recv-keys \"$key\" || ",
-    "    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \"$key\" || ",
+    "    gpg --keyserver pool.sks-keyservers.net --recv-keys \"$key\" || ",
     "    gpg --keyserver pgp.mit.edu --recv-keys \"$key\" || ",
     "    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys \"$key\" || ",
     "    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys \"$key\" || ",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@isx/build",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@isx/build",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-alpha.10",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Two members were recently added[1, 2] to Node's release team, but they're missing from ISX's list of keys. This PR adds them and bumps ISX's package version.

[1] https://github.com/nodejs/node/commit/96fd6810b697aa0ec9d090c010f25f139f3995c7
[2] https://github.com/nodejs/node/commit/1b6565b13c0eaa96416f09972acf89a6d8e18cfd